### PR TITLE
use installer-latest file

### DIFF
--- a/slack_sdk_azure/oauth/installation_store/azure_blob/__init__.py
+++ b/slack_sdk_azure/oauth/installation_store/azure_blob/__init__.py
@@ -158,7 +158,7 @@ class AzureBlobInstallationStore(InstallationStore, AsyncInstallationStore):
             t_id = none
         workspace_path = f"{self.client_id}/{e_id}-{t_id}"
         try:
-            key = f"{workspace_path}/installer-{user_id}-latest" if user_id else f"{workspace_path}/installer-latest"
+            key = f"{workspace_path}/installer-latest"
             data = self.download(key)
             if data is None:
                 data = {}


### PR DESCRIPTION
Azure Functionsのエラーを見ていると、 ユーザー(user_id)毎にファイルが存在する想定の挙動になっており、

- `installer-U064KLXXXXX-latest`
- `installer-U02P4RKXXXX-latest`

などを見に行って 404 で処理が止まっているため、確実に存在するファイルを参照するように修正

